### PR TITLE
replace header with headers and add content-type for PUT

### DIFF
--- a/test/surface/create-container.test.ts
+++ b/test/surface/create-container.test.ts
@@ -35,6 +35,9 @@ describe("Create container", () => {
         // that will be one of the tested behaviours:
         await authFetcher.fetch(`${containerUrl}exists.ttl`, {
           method: "PUT",
+          headers: {
+            "content-type": "text/turtle"
+          },
           body: "<#hello> <#linked> <#world> .",
         });
 
@@ -51,7 +54,7 @@ describe("Create container", () => {
         const result = await authFetcher.fetch(resourceUrl, {
           method: "PUT",
           headers: {
-            "Content-Type": "text/plain",
+            "Content-Type": "text/turtle",
             "If-None-Match": "*",
             Link: '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"', // See https://github.com/solid/node-solid-server/issues/1465
           },

--- a/test/surface/create-non-container.test.ts
+++ b/test/surface/create-non-container.test.ts
@@ -39,6 +39,9 @@ describe("Create non-container", () => {
         // that will be one of the tested behaviours:
         await authFetcher.fetch(`${containerUrl}exists.ttl`, {
           method: "PUT",
+          headers: {
+            "Content-Type": "text/turtle",
+          },
           body: "<#hello> <#linked> <#world> .",
         });
 
@@ -46,7 +49,7 @@ describe("Create non-container", () => {
         await websocketsPubsubClient.getReady();
         const result = await authFetcher.fetch(containerUrl, {
           method: "POST",
-          header: {
+          headers: {
             "Content-Type": "text/plain",
           },
           body: "Hello World",
@@ -98,6 +101,9 @@ describe("Create non-container", () => {
         // that will be one of the tested behaviours:
         await authFetcher.fetch(`${containerUrl}exists.ttl`, {
           method: "PUT",
+          headers: {
+            "Content-Type": "text/turtle"
+          },
           body: "<#hello> <#linked> <#world> .",
         });
 
@@ -113,7 +119,7 @@ describe("Create non-container", () => {
         await websocketsPubsubClientResource.getReady();
         const result = await authFetcher.fetch(resourceUrl, {
           method: "PUT",
-          header: {
+          headers: {
             "Content-Type": "text/plain",
             "If-None-Match": "*",
           },
@@ -169,6 +175,9 @@ describe("Create non-container", () => {
         // that will be one of the tested behaviours:
         await authFetcher.fetch(`${containerUrl}exists.ttl`, {
           method: "PUT",
+          headers: {
+            "Content-Type": "text/turtle"
+          },
           body: "<#hello> <#linked> <#world> .",
         });
 
@@ -268,7 +277,7 @@ describe("Create non-container", () => {
         await websocketsPubsubClientResource.getReady();
         const result = await authFetcher.fetch(resourceUrl, {
           method: "PUT",
-          header: {
+          headers: {
             "Content-Type": "text/plain",
             "If-None-Match": "*",
           },

--- a/test/surface/delete.test.ts
+++ b/test/surface/delete.test.ts
@@ -34,6 +34,9 @@ describe("Delete", () => {
       // that will be one of the tested behaviours:
       await authFetcher.fetch(resourceUrl, {
         method: "PUT",
+        headers: {
+          "content-type": "text/turtle"
+        },
         body: "<#hello> <#linked> <#world> .",
       });
 
@@ -93,6 +96,9 @@ describe("Delete", () => {
       // that will be one of the tested behaviours:
       await authFetcher.fetch(resourceUrl, {
         method: "PUT",
+        headers: {
+          "content-type": "text/turtle"
+        },
         body: "<#hello> <#linked> <#world> .",
       });
 
@@ -153,6 +159,9 @@ describe("Delete", () => {
       // and on non-container delete:
       await authFetcher.fetch(resourceUrl, {
         method: "PUT",
+        headers: {
+          "content-type": "text/turtle"
+        },
         body: "<#hello> <#linked> <#world> .",
       });
       await authFetcher.fetch(resourceUrl, {


### PR DESCRIPTION
- There was a typing error using `fetch header` in place of `fetch headers`
- to be in line with the spec where `content-type` is a MUST in solid/specification for POST, PUT, PATCH I added the content-type when it was missing. Server fail with 4xx when content-type is missing.

When approved the same should be applied to `nss-skips`